### PR TITLE
Add a --dont-notify flag to disable notifications

### DIFF
--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -33,9 +33,15 @@ type Config struct {
 	ConfigInfo map[string]string
 	Experiment string
 	IsTest     bool
-	From       string
-	To         []string
-	Subject    string
+	// Ideally, we would not have this bool in the Config struct, but it is the quickest
+	// way to implement this without a major refactor, especially when this code base is
+	// expected to be deprecated soon. If I'm wrong about this, then in the future, the
+	// logic of whether or not to instantiate a notification should be set by the caller/importer
+	// of this package.
+	DisableNotifications bool
+	From                 string
+	To                   []string
+	Subject              string
 }
 
 // AdminData stores the information needed to generate the Admin notifications

--- a/notifications/utils.go
+++ b/notifications/utils.go
@@ -72,6 +72,11 @@ func NewManager(ctx context.Context, wg *sync.WaitGroup, nConfig Config) Manager
 
 // SendExperimentEmail sends an experiment-specific error message email based on nConfig.  It expects a valid template file configured at notifications.experiment_template
 func SendExperimentEmail(ctx context.Context, nConfig Config, errorTable string) (err error) {
+	if nConfig.DisableNotifications {
+		log.Info("Notifications are disabled.  Not sending experiment email.")
+		return nil
+	}
+
 	var wg sync.WaitGroup
 	var b strings.Builder
 
@@ -137,6 +142,11 @@ func SendExperimentEmail(ctx context.Context, nConfig Config, errorTable string)
 
 // SendAdminNotifications sends admin messages via email and Slack that have been collected in adminMsgSlice. It expects a valid template file configured at nConfig.ConfigInfo["admin_template"].
 func SendAdminNotifications(ctx context.Context, nConfig Config, operation string) error {
+	if nConfig.DisableNotifications {
+		log.Info("Notifications are disabled.  Not sending admin notifications.")
+		return nil
+	}
+
 	var wg sync.WaitGroup
 	var emailErr, slackErr error
 	var b strings.Builder


### PR DESCRIPTION
If `--dont-notify` is given on the command line, disable all notifications from getting sent.